### PR TITLE
[config] Remove "reset failed" print lines from config reload

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -683,7 +683,6 @@ def _get_sonic_services():
 
 def _reset_failed_services():
     for service in _get_sonic_services():
-        click.echo("Resetting failed status on {}".format(service))
         clicommon.run_command("systemctl reset-failed {}".format(service))
 
 


### PR DESCRIPTION
#### What I did
I removed the following line from the `config reload` flow....

```
click.echo("Resetting failed status on {}".format(service))
```

This is called in the `_reset_failed_services()` function which is used to reset the systemd restart timers on services so that it doesn't prevent them from starting from the config reload. 

The above line results in the following lines being printed to the terminal when `config reload` is run

```
Resetting failed status on bgp.service
Resetting failed status on caclmgrd.service
Resetting failed status on dhcp_relay.service
Resetting failed status on hostcfgd.service
Resetting failed status on hostname-config.service
Resetting failed status on interfaces-config.service
Resetting failed status on lldp.service
Resetting failed status on mgmt-framework.timer
Resetting failed status on nat.service
Resetting failed status on ntp-config.service
Resetting failed status on pmon.service
Resetting failed status on procdockerstatsd.service
Resetting failed status on radv.service
Resetting failed status on rsyslog-config.service
Resetting failed status on sflow.service
Resetting failed status on swss.service
Resetting failed status on syncd.service
Resetting failed status on teamd.service
Resetting failed status on telemetry.timer
```

This gives the impression that the listed services failed at some point in their lifetime which is untrue and misleading to print to the terminal (in addition many rich-text terminals mark keywords such as "failed" red which further increases the implied severity of these log lines). I do not believe this operation needs any verbosity as it is a very simple operation that makes no user-visible changes thus the user should not need to be notified of it. 

#### How I did it
Removed the `click.echo` call

#### How to verify it
Run `config reload` and verify that the lines above are not printed to the terminal.

#### Previous command output (if the output of a command-line utility has changed)

```
admin@sonic:~$ sudo config reload -y
Disabling container monitoring ...
Stopping SONiC target ...
Running command: /usr/local/bin/sonic-cfggen -j /etc/sonic/init_cfg.json -j /etc/sonic/config_db.json --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate
Resetting failed status on bgp.service
Resetting failed status on caclmgrd.service
Resetting failed status on dhcp_relay.service
Resetting failed status on hostcfgd.service
Resetting failed status on hostname-config.service
Resetting failed status on interfaces-config.service
Resetting failed status on lldp.service
Resetting failed status on mgmt-framework.timer
Resetting failed status on nat.service
Resetting failed status on ntp-config.service
Resetting failed status on pmon.service
Resetting failed status on procdockerstatsd.service
Resetting failed status on radv.service
Resetting failed status on rsyslog-config.service
Resetting failed status on sflow.service
Resetting failed status on swss.service
Resetting failed status on syncd.service
Resetting failed status on teamd.service
Resetting failed status on telemetry.timer
Restarting SONiC target ...
Enabling container monitoring ...
Reloading Monit configuration ...
Reinitializing monit daemon
```

#### New command output (if the output of a command-line utility has changed)

```
admin@mts-sonic-dut:~$ sudo config reload -y
Disabling container monitoring ...
Stopping SONiC target ...
Running command: /usr/local/bin/sonic-cfggen -j /etc/sonic/init_cfg.json -j /etc/sonic/config_db.json --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate
Restarting SONiC target ...
Enabling container monitoring ...
Reloading Monit configuration ...
Reinitializing monit daemon
```